### PR TITLE
feat: add a tag-version task

### DIFF
--- a/bases/build/src/makejack/build/targets.clj
+++ b/bases/build/src/makejack/build/targets.clj
@@ -37,3 +37,8 @@
   "install jar to local maven repository."
   [params]
   (tasks/install params))
+
+(defn tag-version
+  "Add a git tag with the latest version tag."
+  [params]
+  (tasks/tag-version params))

--- a/bases/tasks/deps.edn
+++ b/bases/tasks/deps.edn
@@ -4,6 +4,7 @@
   makejack/defaults             {:local/root "../../components/defaults"}
   makejack/file-changed         {:local/root "../../components/file-changed"}
   makejack/filesystem           {:local/root "../../components/filesystem"}
+  makejack/git                  {:local/root "../../components/git"}
   makejack/paths                {:local/root "../../components/path"}
   makejack/poly                 {:local/root "../../components/poly"}
   makejack/project-data         {:local/root "../../components/project-data"}

--- a/bases/tasks/src/makejack/tasks/core.clj
+++ b/bases/tasks/src/makejack/tasks/core.clj
@@ -10,12 +10,11 @@
   :verbose true
 
   The :lib and :version keys are populated from `project.edn` if
-  present, else must be manually supplied.
-
-  "
+  present, else must be manually supplied."
   (:require
    [clojure.tools.build.api :as b]
    [makejack.defaults.api :as defaults]
+   [makejack.git.api :as git]
    [makejack.path.api :as path]
    [makejack.project-data.api :as project-data]
    [makejack.target-doc.api :as target-doc]
@@ -78,7 +77,7 @@
 (defn uber
   "Build an uberjar file"
   [params]
-  (v/println params "Build jar...")
+  (v/println params "Build uberjar...")
   (let [params    (defaults/project-data params)
         params    (project-data/expand-version params)
         jar-path  (path/path
@@ -117,4 +116,17 @@
       :jar-file  (str jar-path)
       :lib       (:name params)
       :version   (:version params)})
+    params))
+
+(defn tag-version
+  "Tag the HEAD sha with the project version."
+  [params]
+  (v/println params "Tag version...")
+  (let [params (defaults/project-data params)
+        params (project-data/expand-version params)
+        tag    (defaults/git-tag-for-version params)]
+    (git/tag
+     (merge
+      (select-keys params [:dir])
+      {:tag tag}))
     params))

--- a/components/defaults/src/makejack/defaults/api.clj
+++ b/components/defaults/src/makejack/defaults/api.clj
@@ -43,3 +43,8 @@
   "Adds .keep files to the default jar-ignores"
   []
   impl/jar-ignores)
+
+(defn git-tag-for-version
+  "Return the git tag for the :version in params."
+  [params]
+  (impl/git-tag-for-version params))

--- a/components/defaults/src/makejack/defaults/impl.clj
+++ b/components/defaults/src/makejack/defaults/impl.clj
@@ -46,3 +46,7 @@
 (def jar-ignores
   "Adds .keep files to the default jar-ignores"
   [".*~$" "^#.*#$" "^\\.#.*" "^.DS_Store$" "^.keep$"])
+
+(defn git-tag-for-version
+  [params]
+  (str "v" (:version params)))

--- a/components/git/deps.edn
+++ b/components/git/deps.edn
@@ -1,0 +1,4 @@
+{:paths   ["src"]
+ :deps    {io.github.clojure/tools.build {:git/tag "v0.6.2" :git/sha "226fb52"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps  {}}}}

--- a/components/git/src/makejack/git/api.clj
+++ b/components/git/src/makejack/git/api.clj
@@ -1,0 +1,18 @@
+(ns makejack.git.api
+  "Git command line tasks"
+  (:require [makejack.git.impl :as impl]))
+
+
+(defn tag
+  "Shells out to git and tag a commit-like (commit-sha, tag, etc)
+    git tag HEAD <tag>
+
+  Return the command output.
+
+  Options:
+    :dir - dir to invoke this command from, by default current directory
+    :commit - the commit to tag, e.g a sha, HEAD by default
+    :tag - tag tp add"
+  {:arglists '[[{:keys [commit dir tag]}]]}
+  [params]
+  (impl/tag params))

--- a/components/git/src/makejack/git/impl.clj
+++ b/components/git/src/makejack/git/impl.clj
@@ -1,0 +1,12 @@
+(ns makejack.git.impl
+  (:require
+   [clojure.tools.build.api :as b]))
+
+(defn tag
+  [{:keys [commit dir tag] :or {dir "."}}]
+  (assert tag)
+  (-> {:command-args (cond-> ["git" "tag" tag (or commit"HEAD")])
+       :dir          (.getPath (b/resolve-path dir))
+       :out          :capture}
+      b/process
+      :out))

--- a/components/git/test/makejack/git/api_test.clj
+++ b/components/git/test/makejack/git/api_test.clj
@@ -1,0 +1,6 @@
+(ns makejack.git.api-test
+  (:require [clojure.test :as test :refer :all]
+            [makejack.git.api :as git]))
+
+(deftest dummy-test
+  (is (= 1 1)))

--- a/deps.edn
+++ b/deps.edn
@@ -9,6 +9,7 @@
     makejack/defaults            {:local/root "components/defaults"}
     makejack/file-changed        {:local/root "components/file-changed"}
     makejack/filesystem          {:local/root "components/filesystem"}
+    makejack/git                 {:local/root "components/git"}
     makejack/paths               {:local/root "components/path"}
     makejack/poly                {:local/root "components/poly"}
     makejack/project-data        {:local/root "components/project-data"}

--- a/projects/makejack-jar/deps.edn
+++ b/projects/makejack-jar/deps.edn
@@ -4,6 +4,7 @@
   makejack/defaults     {:local/root "../../components/defaults"}
   makejack/file-changed {:local/root "../../components/file-changed"}
   makejack/filesystem   {:local/root "../../components/filesystem"}
+  makejack/git          {:local/root "../../components/git"}
   makejack/paths        {:local/root "../../components/path"}
   makejack/poly         {:local/root "../../components/poly"}
   makejack/project-data {:local/root "../../components/project-data"}


### PR DESCRIPTION
Tags HEAD with the current project version tag.

- add tag-version task

- adds a defaults/git-tag-for-version function that pefixes the
  version with "v"

Closes #7