### PR TITLE
fix: fix files implementation and reading of non-clj files

### DIFF
--- a/bases/tasks/src/makejack/tasks/compile_clj.clj
+++ b/bases/tasks/src/makejack/tasks/compile_clj.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.tools.build.api :as b]
    [makejack.defaults.api :as defaults]
+   [makejack.deps.api :as deps]
    [makejack.files.api :as files]
    [makejack.verbose.api :as v]))
 
@@ -9,7 +10,7 @@
   "AOT complilation"
   [params]
   (v/println params "compile-clj...")
-  (let [basis     (defaults/basis params)
+  (let [basis     (deps/lift-local-deps (defaults/basis params))
         class-dir (defaults/classes-path params)
         info-map  (files/info-map params (defaults/paths basis))
         _         (assert (some? info-map))

--- a/bases/tasks/src/makejack/tasks/ns_tree.clj
+++ b/bases/tasks/src/makejack/tasks/ns_tree.clj
@@ -1,14 +1,23 @@
 (ns makejack.tasks.ns-tree
   (:require
+   [babashka.fs :as fs]
    [clojure.pprint :as pprint]
    [makejack.defaults.api :as defaults]
+   [makejack.deps.api :as deps]
    [makejack.files.api :as files]))
 
 (defn ns-tree
   "Return namespace tree info."
   [params]
   (let [basis    (defaults/basis params)
-        info-map (files/info-map params (defaults/paths basis))]
+        info-map (->> basis
+                      deps/lift-local-deps
+                      defaults/paths
+                      (mapv #(fs/relativize
+                              (fs/absolutize (fs/path (:dir params ".")))
+                              (fs/absolutize (fs/path %))))
+                      (files/info-map params)
+                      )]
     (println "Unreferenced namespaces"
              (files/top-level-nses info-map))
     (pprint/pprint

--- a/components/defaults/src/makejack/defaults/impl.clj
+++ b/components/defaults/src/makejack/defaults/impl.clj
@@ -30,9 +30,10 @@
   [params]
   (let [aliases (:aliases params)]
     (binding [b/*project-root* (:dir params ".")]
-      (-> (b/create-basis (select-keys
-                           params
-                           [:aliases :project :root :user :extra]))))))
+      (-> (b/create-basis
+           (select-keys
+            params
+            [:aliases :project :root :user :extra]))))))
 
 (defn paths
   "Return the basis :paths"

--- a/components/namespace/src/makejack/namespace/impl.clj
+++ b/components/namespace/src/makejack/namespace/impl.clj
@@ -20,9 +20,10 @@
     (let [options (assoc reader-opts :eof ::eof)
           form    (read options io-reader)]
       (cond
-        (= ::eof form)                nil
-        (namespace-declaration? form) form
-        :else                         (recur)))))
+        (= ::eof form)                        nil
+        (= :sci.impl.parser.edamame/eof form) nil
+        (namespace-declaration? form)         form
+        :else                                 (recur)))))
 
 (defn read-features
   "read options to read conditionals with the :clj feature."
@@ -37,7 +38,9 @@
                        (PushbackReader.
                         (io/reader
                          (fs/file (fs/path path)))))]
-     (read-namespace-declaration reader (read-features features)))))
+     (try
+       (read-namespace-declaration reader (read-features features))
+       (catch Exception _)))))
 
 (defn declared-ns [form]
   (second form))

--- a/mj
+++ b/mj
@@ -23,9 +23,16 @@
 (require 'spartan.spec)
 
 (deps/add-deps '{:deps
+                 {org.clojure/tools.namespace
+                  {:git/url "https://github.com/babashka/tools.namespace"
+                   :git/sha "3625153ee66dfcec2ba600851b5b2cbdab8fae6c"}}})
+
+
+(deps/add-deps '{:deps
                  {io.github.clojure/tools.build
-                  {:git/url "https://github.com/babashka/tools.bbuild"
-                   :git/sha "af73f5a1ffe209291aa80215495a7959e1032d39"}}})
+                  {:git/url    "https://github.com/babashka/tools.bbuild"
+                   :git/sha    "af73f5a1ffe209291aa80215495a7959e1032d39"
+                   :exclusions [org.clojure/tools.namespace]}}})
 
 (require 'clojure.tools.build.api)
 (require 'clojure.tools.deps.alpha)
@@ -62,10 +69,13 @@
                       (parse-namespace task-file)
                       str)
                      (assert false "Task file must contain a ns form"))
-                 "makejack.tasks")]
+                 "makejack.tasks")
+        f      (symbol (or (first args) "help"))
+        f      (if (namespace f) f (symbol ns-str (name f)))
+        ns-str (namespace f)]
     {:task-file task-file
      :ns-str    ns-str
-     :f         (or (first args) "help")
+     :f         f
      :args      (into {} (->> args
                               rest
                               (mapv read-or-identity)
@@ -77,6 +87,7 @@
   (if task-file
     (load-file task-file)
     (require 'makejack.tasks))
-  ((resolve (symbol ns-str f)) args))
+  (require (symbol ns-str))
+  ((resolve f) args))
 
 nil


### PR DESCRIPTION
Fixes some partial refactoring in files.impl, and parsing of non
namespace files in namespace/impl.

Improves mj script to allow passing fully qualified task symbol.